### PR TITLE
Fix key binding to toggle output mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ modes:
 
 The default mode is "result", which means that by default, whatever is in the
 result pane will be printed to stdout when ``jpterm`` exits.  You can switch
-output modes using ``Ctrl-p``, which will cycle through the three modes above.
+output modes using ``Ctrl-o``, which will cycle through the three modes above.
 You can also specify what mode to use when starting the ``jpterm`` command
 using the ``-m/--output-mode`` command line option.
 
@@ -72,7 +72,7 @@ Keyboard Shortcuts
 
 ``F5 or Ctrl + c``
     | Quit the program.
-``Ctrl + p``
+``Ctrl + o``
     | Output mode toggle.  Toggle between outputting the current result,
     | expression, or nothing.  This is discussed in the "Output" section above.
 ``Ctrl + ]``

--- a/jpterm.py
+++ b/jpterm.py
@@ -157,7 +157,7 @@ class JMESPathDisplay(object):
             # the current expression current expression.
             self.input_expr.edit_text = ''
             self.jmespath_result.set_text('')
-        elif key == 'ctrl p':
+        elif key == 'ctrl o':
             new_mode = OUTPUT_MODES[
                 (OUTPUT_MODES.index(self.output_mode) + 1) % len(OUTPUT_MODES)]
             self.output_mode = new_mode


### PR DESCRIPTION
The help says that output mode can be changed by Ctrl-o.
https://github.com/jmespath-community/jmespath.terminal/blob/7c0999d84c22facef099977d54bc08b482a9af78/jpterm.py#L207-L212

Current implementation using Ctrl-p.
https://github.com/jmespath-community/jmespath.terminal/blob/7c0999d84c22facef099977d54bc08b482a9af78/jpterm.py#L160-L163

Since it is easier to remember the key bindings for output mode by using o, the first letter of output, I changed the implementation.