### PR TITLE
Fix to print non-ascii characters as-is

### DIFF
--- a/jpterm.py
+++ b/jpterm.py
@@ -98,8 +98,9 @@ class JMESPathDisplay(object):
         urwid.connect_signal(self.input_expr, 'change', self._on_edit)
 
         self.input_json = urwid.Text(
-            self._create_colorized_json(json.dumps(self.parsed_json,
-                                                   indent=2))
+            self._create_colorized_json(
+                json.dumps(self.parsed_json, indent=2, ensure_ascii=False)
+            )
         )
         self.input_json_list = [div, self.input_json]
         self.left_content = urwid.ListBox(self.input_json_list)
@@ -136,7 +137,7 @@ class JMESPathDisplay(object):
             if result is not None:
                 self.last_result = result
                 result_markup = self._create_colorized_json(
-                    json.dumps(result, indent=2))
+                    json.dumps(result, indent=2, ensure_ascii=False))
                 self.jmespath_result.set_text(result_markup)
 
     def main(self, screen=None):
@@ -166,7 +167,7 @@ class JMESPathDisplay(object):
     def display_output(self, filename):
         if self.output_mode == 'result' and \
                 self.last_result is not None:
-            result = json.dumps(self.last_result, indent=2)
+            result = json.dumps(self.last_result, indent=2, ensure_ascii=False)
         elif self.output_mode == 'expression' and \
                 self.last_expression is not None:
             result = self.last_expression

--- a/jpterm.py
+++ b/jpterm.py
@@ -98,9 +98,7 @@ class JMESPathDisplay(object):
         urwid.connect_signal(self.input_expr, 'change', self._on_edit)
 
         self.input_json = urwid.Text(
-            self._create_colorized_json(
-                json.dumps(self.parsed_json, indent=2, ensure_ascii=False)
-            )
+            self._create_colorized_json(self._json_dumps(self.parsed_json))
         )
         self.input_json_list = [div, self.input_json]
         self.left_content = urwid.ListBox(self.input_json_list)
@@ -137,8 +135,11 @@ class JMESPathDisplay(object):
             if result is not None:
                 self.last_result = result
                 result_markup = self._create_colorized_json(
-                    json.dumps(result, indent=2, ensure_ascii=False))
+                    self._json_dumps(result))
                 self.jmespath_result.set_text(result_markup)
+
+    def _json_dumps(self, obj):
+        return json.dumps(obj, indent=2, ensure_ascii=False)
 
     def main(self, screen=None):
         self._create_view()
@@ -167,7 +168,7 @@ class JMESPathDisplay(object):
     def display_output(self, filename):
         if self.output_mode == 'result' and \
                 self.last_result is not None:
-            result = json.dumps(self.last_result, indent=2, ensure_ascii=False)
+            result = self._json_dumps(self.last_result)
         elif self.output_mode == 'expression' and \
                 self.last_expression is not None:
             result = self.last_expression


### PR DESCRIPTION
Current implementation prints non-ascii characters as escaped.
This makes it unreadable and inconvenient.
jp prints non-ascii characters as-is, and jpterm should also do so.

before:
![before](https://github.com/jmespath-community/jmespath.terminal/assets/17674842/0b883fda-feb4-431a-aa62-5fef5504baca)

after:
![after](https://github.com/jmespath-community/jmespath.terminal/assets/17674842/7bbde043-35dd-410c-ae75-5e0bfb2c76ed)
